### PR TITLE
fix: allow keywords as values in other sections

### DIFF
--- a/a2lparser/a2l/a2l_lex.py
+++ b/a2lparser/a2l/a2l_lex.py
@@ -191,7 +191,7 @@ class A2LLex:
             + LexerKeywords.keywords_enum
             + LexerKeywords.keywords_datatypes
         )
-        + r")\b"
+        + r")\b(?![\.\w-])"
     )
     def t_KEYWORD_TYPE(self, t):
         """


### PR DESCRIPTION
This change allows users to have values in groups that contain names of keywords. Before, if I had a `CHARACTERISTIC` with the `Name` value of `SOME_KEYWORD.FOO_BAR` it would fail, if `SOME_KEYWORD` was defined as a keyword. This change allows keywords to exist in values of groups.